### PR TITLE
Bumped PHP version to `5.5` in order to allow to use `guzzlehttp/guzzle:^6.0`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,20 @@
+; top-most EditorConfig file
+root = true
+
+; Unix-style newlines
+[*]
+end_of_line = LF
+
+[*.{php,xml,yml,json}]
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+charset = utf-8
+insert_final_newline = true
+
+[*.{md}]
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true
+charset = utf-8
+insert_final_newline = true

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+* text=auto
+
+# These files are always considered text and should use LF.
+# See core.whitespace @ http://git-scm.com/docs/git-config for whitespace flags.
+*.php   text eol=lf whitespace=blank-at-eol,blank-at-eof,space-before-tab,tab-in-indent,tabwidth=4 diff=php
+*.json  text eol=lf whitespace=blank-at-eol,blank-at-eof,space-before-tab,tab-in-indent,tabwidth=4
+*.yml   text eol=lf whitespace=blank-at-eol,blank-at-eof,space-before-tab,tab-in-indent,tabwidth=4
+*.xml   text eol=lf whitespace=blank-at-eol,blank-at-eof,space-before-tab,tab-in-indent,tabwidth=4 diff=html
+*.md    text eol=lf whitespace=blank-at-eol,blank-at-eof,space-before-tab,tab-in-indent,tabwidth=2 diff=tex

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.php_cs
+/composer.lock
+/phpunit.xml
+/vendor/

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -1,0 +1,57 @@
+<?php
+
+$header = <<<'EOF'
+This file is part of Facturama PHP SDK.
+
+(c) Facturama <dev@facturama.com>
+
+This source file is subject to a MIT license that is bundled
+with this source code in the file LICENSE.
+EOF;
+
+return PhpCsFixer\Config::create()
+    ->setUsingCache(true)
+    ->setRiskyAllowed(true)
+    ->setRules([
+        '@Symfony' => true,
+        '@Symfony:risky' => true,
+        'array_syntax' => ['syntax' => 'short'],
+        'dir_constant' => true,
+        'ereg_to_preg' => true,
+        'general_phpdoc_annotation_remove' => ['expectedException', 'expectedExceptionMessage', 'expectedExceptionMessageRegExp'],
+        'header_comment' => ['header' => $header],
+        'heredoc_to_nowdoc' => true,
+        'linebreak_after_opening_tag' => true,
+        'mb_str_functions' => true,
+        'modernize_types_casting' => true,
+        'no_empty_comment' => true,
+        'no_extra_consecutive_blank_lines' => [
+            'break',
+            'continue',
+            'extra',
+            'return',
+            'throw',
+            'use',
+            'parenthesis_brace_block',
+            'square_brace_block',
+            'curly_brace_block',
+        ],
+        'no_short_echo_tag' => true,
+        'no_useless_else' => true,
+        'no_useless_return' => true,
+        'ordered_class_elements' => true,
+        'ordered_imports' => true,
+        'phpdoc_add_missing_param_annotation' => true,
+        'phpdoc_align' => false,
+        'phpdoc_order' => true,
+        'phpdoc_summary' => false,
+        'php_unit_construct' => true,
+        'php_unit_strict' => true,
+        'psr4' => true,
+    ])
+    ->setFinder(
+        PhpCsFixer\Finder::create()
+            ->exclude(['vendor'])
+            ->in(__DIR__)
+    )
+;

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,29 @@
+sudo: false
+language: php
+
+matrix:
+    include:
+        # Use the newer stack for HHVM as HHVM does not support Precise anymore since a long time and so Precise has an outdated version
+        - php: hhvm-3.12
+          sudo: required
+          dist: trusty
+        - php: 5.5
+        - php: 5.6
+        - php: 7.0
+        - php: 7.1
+    fast_finish: true
+    allow_failures:
+        - php: 7.1
+        - php: nightly
+        - php: hhvm-3.12
+
+before_script:
+  - composer install
+
+script:
+  - ./vendor/bin/phpunit -v -c phpunit.xml.dist
+  - ./vendor/bin/phpmd src/ text phpmd.xml.dist
+
+cache:
+  directories:
+    - $HOME/.composer/cache

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Facturama SDK PHP
+This library requires PHP 5.5 as minimum
 ## How do I install it?
 composer install facturama/facturama-php-sdk:^1.0@dev
 ### Including the Lib

--- a/composer.json
+++ b/composer.json
@@ -15,10 +15,10 @@
         }
     ],
     "require": {
-        "php": ">=5.4",
+        "php": ">=5.5",
         "ext-curl": "*",
         "ext-openssl": "*",
-        "guzzlehttp/guzzle": "^5.3"
+        "guzzlehttp/guzzle": "^6.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.7",

--- a/src/Client.php
+++ b/src/Client.php
@@ -16,7 +16,11 @@ use Facturama\Exception\RequestException;
 use GuzzleHttp\Client as GuzzleClient;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\RequestException as GuzzleRequestException;
+use GuzzleHttp\RequestOptions;
 
+/**
+ * @author Javier Spagnoletti <phansys@gmail.com>
+ */
 class Client
 {
     const VERSION = '1.0.0';
@@ -72,11 +76,13 @@ class Client
      */
     public function __construct($user = null, $password = null, array $config = [])
     {
-        $this->client = new GuzzleClient($config + ['headers' => ['User-Agent' => self::USER_AGENT]]);
-        $this->client->setDefaultOption('verify', false);
-        $this->client->setDefaultOption('auth', [$user, $password]);
-        $this->client->setDefaultOption('connect_timeout', 10);
-        $this->client->setDefaultOption('timeout', 60);
+        $this->client = new GuzzleClient($config + [
+            RequestOptions::HEADERS => ['User-Agent' => self::USER_AGENT],
+            RequestOptions::VERIFY => false,
+            RequestOptions::AUTH => [$user, $password],
+            RequestOptions::CONNECT_TIMEOUT => 10,
+            RequestOptions::TIMEOUT => 60,
+        ]);
     }
 
     /**
@@ -89,7 +95,7 @@ class Client
      */
     public function get($path, array $params = [])
     {
-        return $this->executeRequest('GET', $path, ['query' => $params]);
+        return $this->executeRequest('GET', $path, [RequestOptions::QUERY => $params]);
     }
 
     /**
@@ -103,7 +109,7 @@ class Client
      */
     public function post($path, array $body = null, array $params = [])
     {
-        return $this->executeRequest('POST', $path, ['json' => $body, 'query' => $params]);
+        return $this->executeRequest('POST', $path, [RequestOptions::JSON => $body, RequestOptions::QUERY => $params]);
     }
 
     /**
@@ -117,7 +123,7 @@ class Client
      */
     public function put($path, array $body = null, array $params = [])
     {
-        return $this->executeRequest('PUT', $path, ['json' => $body, 'query' => $params]);
+        return $this->executeRequest('PUT', $path, [RequestOptions::JSON => $body, RequestOptions::QUERY => $params]);
     }
 
     /**
@@ -130,7 +136,7 @@ class Client
      */
     public function delete($path, array $params = [])
     {
-        return $this->executeRequest('DELETE', $path, ['query' => $params]);
+        return $this->executeRequest('DELETE', $path, [RequestOptions::QUERY => $params]);
     }
 
     /**
@@ -147,8 +153,7 @@ class Client
     private function executeRequest($method, $url, array $options = [])
     {
         try {
-            $request = $this->client->createRequest($method, sprintf('%s/%s', self::API_URL, $url), $options);
-            $response = $this->client->send($request);
+            $response = $this->client->request($method, sprintf('%s/%s', self::API_URL, $url), $options);
             $content = trim($response->getBody()->getContents());
         } catch (GuzzleRequestException $e) {
             if ($e->hasResponse()) {


### PR DESCRIPTION
|Q            |A     |
|---          |---   |
|Branch       |master|
|Bug fix?     |no    |
|New feature? |no    |
|BC breaks?   |yes   |
|Deprecations?|no    |
|Tests pass?  |yes   |
|Fixed tickets|n/a   |
|License      |MIT   |
|Doc PR       |n/a   |